### PR TITLE
Reduce memory usage by avoiding full file reads

### DIFF
--- a/makefat.go
+++ b/makefat.go
@@ -6,7 +6,7 @@ import (
 	"debug/macho"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -27,36 +27,56 @@ func main() {
 
 	// Read input files.
 	type input struct {
-		data   []byte
+		file   *os.File
+		size   int64
 		cpu    uint32
 		subcpu uint32
 		offset int64
 	}
 	var inputs []input
+	var head [12]byte
+
 	offset := int64(align)
 	for _, i := range os.Args[2:] {
-		data, err := ioutil.ReadFile(i)
+		file, err := os.Open(i)
 		if err != nil {
 			panic(err)
 		}
-		if len(data) < 12 {
+		defer file.Close()
+		// Read the first 12 bytes of the file and reset the reader
+		fi, err := file.Stat()
+		if err != nil {
+			panic(err)
+		}
+		size := fi.Size()
+		if size < 12 {
 			panic(fmt.Sprintf("file %s too small", i))
 		}
+		n, err := file.Read(head[:])
+		if n != 12 {
+			panic(fmt.Sprintf("tried to read 12 bytes but was able to read %d", n))
+		}
+		if err != nil {
+			panic(err)
+		}
+		if _, err := file.Seek(0, 0); err != nil {
+			panic(err)
+		}
 		// All currently supported mac archs (386,amd64,arm,arm64) are little endian.
-		magic := binary.LittleEndian.Uint32(data[0:4])
+		magic := binary.LittleEndian.Uint32(head[0:4])
 		if magic != macho.Magic32 && magic != macho.Magic64 {
 			panic(fmt.Sprintf("input %s is not a macho file, magic=%x", i, magic))
 		}
-		cpu := binary.LittleEndian.Uint32(data[4:8])
-		subcpu := binary.LittleEndian.Uint32(data[8:12])
-		inputs = append(inputs, input{data: data, cpu: cpu, subcpu: subcpu, offset: offset})
-		offset += int64(len(data))
+		cpu := binary.LittleEndian.Uint32(head[4:8])
+		subcpu := binary.LittleEndian.Uint32(head[8:12])
+		inputs = append(inputs, input{file: file, cpu: cpu, subcpu: subcpu, size: size, offset: offset})
+		offset += size
 		offset = (offset + align - 1) / align * align
 	}
 
 	// Decide on whether we're doing fat32 or fat64.
 	sixtyfour := false
-	if inputs[len(inputs)-1].offset >= 1<<32 || len(inputs[len(inputs)-1].data) >= 1<<32 {
+	if inputs[len(inputs)-1].offset >= 1<<32 || inputs[len(inputs)-1].size >= 1<<32 {
 		sixtyfour = true
 		// fat64 doesn't seem to work:
 		//   - the resulting binary won't run.
@@ -93,9 +113,9 @@ func main() {
 		}
 		hdr = append(hdr, uint32(i.offset))
 		if sixtyfour {
-			hdr = append(hdr, uint32(len(i.data)>>32)) // big endian
+			hdr = append(hdr, uint32(i.size>>32)) // big endian
 		}
-		hdr = append(hdr, uint32(len(i.data)))
+		hdr = append(hdr, uint32(i.size))
 		hdr = append(hdr, alignBits)
 		if sixtyfour {
 			hdr = append(hdr, 0) // reserved
@@ -120,11 +140,14 @@ func main() {
 			}
 			offset = i.offset
 		}
-		_, err := out.Write(i.data)
+		n, err := io.Copy(out, i.file)
 		if err != nil {
 			panic(err)
 		}
-		offset += int64(len(i.data))
+		if n != i.size {
+			panic(fmt.Sprintf("expected to copy over %d bytes but copied over %d", i.size, n))
+		}
+		offset += int64(i.size)
 	}
 	err = out.Close()
 	if err != nil {


### PR DESCRIPTION
#### What does this PR do?

Prior to this change the application would copy all of the binaries in memory, use the first 12 bytes and copy the rest verbatim into the new output file.

#### How was this tested?

I built the binary from both the current `master` (`7ddd0e4`) and this branch, applying a simple print out of the memory allocated for both.

<details>
<summary>memory print-out patch</summary>

```diff
index 9ff733a..17b4a2e 100644
--- a/makefat.go
+++ b/makefat.go
@@ -8,6 +8,7 @@ import (
        "fmt"
        "io"
        "os"
+       "runtime"
 )

 const (
@@ -25,6 +26,11 @@ func main() {
                os.Exit(2)
        }

+
+       var ms1, ms2 runtime.MemStats
+       runtime.GC()
+       runtime.ReadMemStats(&ms1)
+
        // Read input files.
        type input struct {
                file   *os.File
@@ -134,6 +140,7 @@ func main() {
        // Write each contained file.
        for _, i := range inputs {
                if offset < i.offset {
+                       fmt.Println("adjusting offset:", i.offset-offset)
                        _, err = out.Write(make([]byte, i.offset-offset))
                        if err != nil {
                                panic(err)
@@ -153,4 +160,9 @@ func main() {
        if err != nil {
                panic(err)
        }
+
+       runtime.ReadMemStats(&ms2)
+       fmt.Println("total:   ", ms2.TotalAlloc - ms1.TotalAlloc, "bytes")
+       fmt.Println("adjusted:", ms2.HeapAlloc - ms1.HeapAlloc, "bytes")
+       fmt.Println("mallocs: ", ms2.Mallocs - ms1.Mallocs)
 }
 ```

</details>

I then ran the built binaries against a simple "Hello, world!" Go binary built for amd64 and arm64 and fed them to both `makefat` versions.

<details>
<summary>Dummy binary</summary>

```go
// filename: hello.go
import "fmt"

func main() {
	fmt.Println("Hello, world!")
}
```

```bash
# Building the binaries
GOARCH=amd64 go build -o world_amd64 ./hello.go
GOARCH=arm64 go build -o world_arm64 ./hello.go
```

```bash
$ ls -la world_*
-rwxr-xr-x  1 the_mac  staff  2569248 Apr  6 19:20 world_amd64
-rwxr-xr-x  1 the_mac  staff  2492514 Apr  6 19:09 world_arm64
```

</details>

#### What are the results of the changes

`makefat` now doesn't scale its memory usage with binary input size.

```
makefat (master)

adjusting offset: 16336
adjusting offset: 3040
total:    5093048 bytes
adjusted: 5092512 bytes
mallocs:  28

-----------------------

makefat (new)
adjusting offset: 16336
adjusting offset: 3040
total:    87800 bytes
adjusted: 87800 bytes
mallocs:  31
```

I've also tried it with a much larger Go binary (~25MB) and the new results are similar

```
$ ls -la larger_{amd64,arm64}
-rwxr-xr-x@ 1 the_mac  staff  25569440 Apr  6 19:43 larger_amd64
-rwxr-xr-x@ 1 the_mac  staff  24414194 Apr  6 19:43 larger_arm64

$ ./makefat_master testing_both larger_{amd64,arm64}
adjusting offset: 16336
adjusting offset: 5984
total:    50021432 bytes
adjusted: 50021128 bytes
mallocs:  30

$ ./makefat_new testing_both larger_{amd64,arm64}
adjusting offset: 16336
adjusting offset: 5984
total:    91032 bytes
adjusted: 91032 bytes
mallocs:  31
```

#### Caveats

- The `io.Copy` call does not pass in a buffer so Go allocates a new 32kb one on each call